### PR TITLE
feature: 로그인 시 쿠키에 jwt token 저장 기능 추가

### DIFF
--- a/app/(auth)/signin/_components/signinForm.tsx
+++ b/app/(auth)/signin/_components/signinForm.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 
 import Button from '@/components/button/button';
 import Input from '@/components/input/input';
+import ROUTE_PATHS from '@/constants/route';
 import { postSignIn } from '@/services/api';
 
 interface FieldValues {
@@ -56,7 +57,7 @@ export default function SignInForm() {
     try {
       await postSignIn(data);
 
-      router.push('/');
+      router.push(ROUTE_PATHS.HOME);
     } catch (error) {
       if (error instanceof AxiosError) {
         const errorMessage = error.response?.status === 404 ? error.response.data.message : '로그인에 실패했습니다.';

--- a/app/(auth)/signin/_components/signinForm.tsx
+++ b/app/(auth)/signin/_components/signinForm.tsx
@@ -55,7 +55,11 @@ export default function SignInForm() {
 
   const onSubmit = async (data: FieldValues) => {
     try {
-      await postSignIn(data);
+      const {
+        item: { token },
+      } = await postSignIn(data);
+
+      document.cookie = `accessToken=${token}; Path=/; Max-Age=86400; Secure; SameSite=Strict`;
 
       router.push(ROUTE_PATHS.HOME);
     } catch (error) {

--- a/app/(auth)/signin/_components/signinForm.tsx
+++ b/app/(auth)/signin/_components/signinForm.tsx
@@ -79,7 +79,7 @@ export default function SignInForm() {
           {...register(name as keyof FieldValues, validation)}
         />
       ))}
-      <Button background="bg-primary" fontSize={16} height={48}>
+      <Button background="bg-primary" className="w-full h-[48px]">
         로그인 하기
       </Button>
     </form>

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 
+import ROUTE_PATHS from '@/constants/route';
+
 import SigninForm from './_components/signinForm';
 
 export default function Signin() {
@@ -9,7 +11,7 @@ export default function Signin() {
       <p className="mt-5 text-black">
         회원이 아니신가요?{' '}
         <span className="text-[#5534DA] underline">
-          <Link href="/signup">회원가입하기</Link>
+          <Link href={ROUTE_PATHS.SIGN_UP}>회원가입하기</Link>
         </span>
       </p>
     </div>

--- a/app/(auth)/signup/_components/signupForm.tsx
+++ b/app/(auth)/signup/_components/signupForm.tsx
@@ -106,7 +106,7 @@ export default function SignUpForm() {
         control={control}
         render={({ field: { onChange, value } }) => <MemberType value={value} onChange={onChange} />}
       />
-      <Button background="bg-primary" fontSize={16} height={48}>
+      <Button background="bg-primary" className="w-full h-[48px]">
         가입하기
       </Button>
     </form>

--- a/constants/route.ts
+++ b/constants/route.ts
@@ -1,6 +1,7 @@
 const ROUTE_PATHS = {
   HOME: '/',
   SIGN_IN: '/signin',
+  SIGN_UP: '/signup',
 } as const;
 
 export default ROUTE_PATHS;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 로그인 성공 시 쿠키에 `accessToken` 이름으로 jwt token이 저장되도록 기능을 추가하였습니다.

## 📝 참고 사항

- 쿠키는 24시간 동안 유효합니다.
- dev 서버에서 실행 시, 아래 코드에서 `Secure`를 지워주셔야 합니다. dev 서버의 경우 `https`가 아닌 `http`이기 때문에, `secure` 설정 시 토큰이 제대로 동작하지 않을 수 있습니다.

  ```tsx
    const onSubmit = async (data: FieldValues) => {
      try {
        const {
          item: { token },
        } = await postSignIn(data);
  
        document.cookie = `accessToken=${token}; Path=/; Max-Age=86400; Secure; SameSite=Strict`;
  
        router.push(ROUTE_PATHS.HOME);
      } catch (error) {
        if (error instanceof AxiosError) {
          const errorMessage = error.response?.status === 404 ? error.response.data.message : '로그인에 실패했습니다.';
          alert(errorMessage);
        }
      }
    };
  ```

## 🖼️ 스크린샷

<img width="960" alt="image" src="https://github.com/5-PS/The-Julge/assets/79499733/9f5074ac-179c-4bdc-97ab-b8887a0669e1">

## 🚨 관련 이슈

- 현재 쿠키에 `HttpOnly` 설정이 되어있지 않습니다.

## ✅ 이후 계획

- 쿠키에 `HttpOnly` 설정 예정입니다.
- 로그인 시 직전 페이지로 이동할 수 있도록 코드 수정 예정입니다.
