### PR TITLE
feature: table state badge component

### DIFF
--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -563,41 +563,6 @@ const STORE_INFORMATION: {
     state: 'pedding',
   },
 ];
-// TODO: 뱃지 컴포넌트로 따로 분리하기
-function StateBadge({ state }: StateBadgeProps) {
-  if (state === 'pedding') {
-    return (
-      <span className="state-badge bg-green-10 text-green-20">
-        <strong>대기중</strong>
-      </span>
-    );
-  }
-  if (state === 'approve') {
-    return (
-      <span className="state-badge bg-blue-10 text-blue-20">
-        <strong>승인 완료</strong>
-      </span>
-    );
-  }
-  if (state === 'choose') {
-    return (
-      <div className="flex gap-[8px]">
-        <button
-          type="button"
-          className="px-[12px] py-[8px] text-[10px] rounded-[6px] border border-red-40 text-red-40 md:px-[20px] md:py-[10px] md:text-[14px]"
-        >
-          <strong>거절하기</strong>
-        </button>
-        <button
-          type="button"
-          className="px-[12px] py-[8px] text-[10px]  rounded-[6px] border border-blue-20 text-blue-20 md:px-[20px] md:py-[10px] md:text-[14px]"
-        >
-          <strong>승인하기</strong>
-        </button>
-      </div>
-    );
-  }
-}
 
 function Table({ query, type }: { query: { page: string }; type: 'applicantList' | 'applyList' }) {
   const defaultQueryPage = query.page || '1';
@@ -630,9 +595,7 @@ function Table({ query, type }: { query: { page: string }; type: 'applicantList'
                 <td className="sticky left-0 bg-white tb-data ">{store.title}</td>
                 <td className="tb-data ">{store.date}</td>
                 <td className="tb-data ">{store.money}</td>
-                <td className="tb-data " aria-label="badge">
-                  <StateBadge state={store.state} />
-                </td>
+                <td className="tb-data " aria-label="badge" />
               </tr>
             ))}
           </tbody>

--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -1,19 +1,168 @@
 import Pagination from '../pagination/pagination';
+import ApplicationTableStateBadge from '../tableStateBadge/applicationTableStateBadge';
+import ApplyTableStateBadge from '../tableStateBadge/applyTableStateBadge';
 
-interface StateBadgeProps {
-  state: 'pedding' | 'approve' | 'choose';
-}
 // api가 없어 만든 임시 데이터 입니다.
 const STORE_INFORMATION: {
   title: string;
   date: string;
   money: number;
-  state: 'pedding' | 'approve' | 'choose';
+  state: 'pending' | 'accepted' | 'rejected';
 }[] = [
   {
     title: '너구리네 라면집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
+    state: 'rejected',
+  },
+  {
+    title: '너구리네 국수집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'accepted',
+  },
+  {
+    title: '너구리네 돈까스집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'accepted',
+  },
+  {
+    title: '너구리네 짜장면집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 카레집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 우동집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 몰라',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 밥집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 한식집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 ㅠㅠㅠ',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 ㅁㄴㅇㅁㄴ',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 술집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 피시방',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 놀이공원',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 기둥',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 흠 뭐하지',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 진짜 뭐하지',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 학원',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 ㅁㄴㅇ',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 ㅁㄴㅇㅁㄴㅇㅁ',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 라면집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 칼국수집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 ㅁㅁㅁ',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 코딩집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 ㅠㅠㅠㅠ',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 라면집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
     state: 'choose',
   },
   {
@@ -26,547 +175,396 @@ const STORE_INFORMATION: {
     title: '너구리네 돈까스집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 짜장면집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 카레집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 우동집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 몰라',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 밥집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 한식집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㄴㅇㅁㄴ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 술집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 피시방',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 놀이공원',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 기둥',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 흠 뭐하지',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 진짜 뭐하지',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 학원',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㄴㅇ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㄴㅇㅁㄴㅇㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 라면집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 라면집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'choose',
-  },
-  {
-    title: '너구리네 국수집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'approve',
-  },
-  {
-    title: '너구리네 돈까스집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 짜장면집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 카레집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 우동집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 몰라',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 밥집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 한식집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 ㅠㅠㅠ',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 ㅁㄴㅇㅁㄴ',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 술집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 피시방',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 놀이공원',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 기둥',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 흠 뭐하지',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 진짜 뭐하지',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 학원',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 ㅁㄴㅇ',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 ㅁㄴㅇㅁㄴㅇㅁ',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 라면집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
+  },
+  {
+    title: '너구리네 코딩집',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
+  },
+  {
+    title: '너구리네 ㅠㅠㅠㅠ',
+    date: '2023.01.12~12:00 (2시간)',
+    money: 12500,
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 칼국수집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅁㅁㅁ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 코딩집',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
   {
     title: '너구리네 ㅠㅠㅠㅠ',
     date: '2023.01.12~12:00 (2시간)',
     money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 코딩집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 ㅠㅠㅠㅠ',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 칼국수집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 ㅁㅁㅁ',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 코딩집',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
-  },
-  {
-    title: '너구리네 ㅠㅠㅠㅠ',
-    date: '2023.01.12~12:00 (2시간)',
-    money: 12500,
-    state: 'pedding',
+    state: 'pending',
   },
 ];
 
 function Table({ query, type }: { query: { page: string }; type: 'applicantList' | 'applyList' }) {
   const defaultQueryPage = query.page || '1';
-  const pageLength = Math.ceil(STORE_INFORMATION.length / 5);
   const sliceIndex = (parseInt(defaultQueryPage, 10) - 1) * 5;
   return (
     <div className="relative w-full max-w-[964px] overflow-hidden border border-gray-20 rounded-[10px] bg-white m-auto">
@@ -595,13 +593,19 @@ function Table({ query, type }: { query: { page: string }; type: 'applicantList'
                 <td className="sticky left-0 bg-white tb-data ">{store.title}</td>
                 <td className="tb-data ">{store.date}</td>
                 <td className="tb-data ">{store.money}</td>
-                <td className="tb-data " aria-label="badge" />
+                <td className="tb-data " aria-label="badge">
+                  {type === 'applicantList' ? (
+                    <ApplicationTableStateBadge state={store.state} />
+                  ) : (
+                    <ApplyTableStateBadge state={store.state} />
+                  )}
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      <Pagination page={query.page} pageLength={pageLength} />
+      <Pagination page={query.page} totalDataCount={STORE_INFORMATION.length} sliceDataValue={5} />
     </div>
   );
 }

--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -584,7 +584,7 @@ function Table({ query, type }: { query: { page: string }; type: 'applicantList'
                 {type === 'applicantList' && '전화번호'}
                 {type === 'applyList' && '시급'}
               </th>
-              <th className="tb-head w-[165px] md:w-[236px]">상태</th>
+              <th className="tb-head sticky right-0 bg-red-10 w-[165px] md:w-[236px]">상태</th>
             </tr>
           </thead>
           <tbody>
@@ -593,7 +593,7 @@ function Table({ query, type }: { query: { page: string }; type: 'applicantList'
                 <td className="sticky left-0 bg-white tb-data ">{store.title}</td>
                 <td className="tb-data ">{store.date}</td>
                 <td className="tb-data ">{store.money}</td>
-                <td className="tb-data " aria-label="badge">
+                <td className="tb-data sticky bg-white right-0" aria-label="badge">
                   {type === 'applicantList' ? (
                     <ApplicationTableStateBadge state={store.state} />
                   ) : (

--- a/components/tableStateBadge/applicationTableStateBadge.tsx
+++ b/components/tableStateBadge/applicationTableStateBadge.tsx
@@ -1,0 +1,14 @@
+import ApplyTableStateBadge from './applyTableStateBadge';
+import PendingBtn from './pendingBtn';
+
+interface ApplicationTableStateBadgeProps {
+  state: 'pending' | 'accepted' | 'rejected';
+}
+
+export default function ApplicationTableStateBadge({ state }: ApplicationTableStateBadgeProps) {
+  if (state === 'pending') {
+    return <PendingBtn />;
+  }
+
+  return <ApplyTableStateBadge state={state} />;
+}

--- a/components/tableStateBadge/applyTableStateBadge.tsx
+++ b/components/tableStateBadge/applyTableStateBadge.tsx
@@ -1,11 +1,13 @@
 interface ApplyTableStateBadgeProps {
-  state: 'pending' | 'accepted ' | 'rejected';
+  state: 'pending' | 'accepted' | 'rejected';
 }
 
 export default function ApplyTableStateBadge({ state }: ApplyTableStateBadgeProps) {
-  const badgeStyle = `${state === 'accepted ' ? 'bg-blue-10 text-blue-20' : ''}${state === 'pending' ? 'bg-green-10 text-green-20' : ''}${state === 'rejected' ? 'bg-red-200 text-red-500' : ''}`;
-  const badgeText = `${state === 'accepted ' ? '승인 완료' : ''}${state === 'pending' ? '대기중' : ''}${state === 'rejected' ? '거절' : ''}`;
+  const badgeStyle = `${state === 'accepted' ? 'bg-blue-10 text-blue-20' : ''}${state === 'pending' ? 'bg-green-10 text-green-20' : ''}${state === 'rejected' ? 'bg-red-200 text-red-500' : ''}`;
+  const badgeText = `${state === 'accepted' ? '승인 완료' : ''}${state === 'pending' ? '대기중' : ''}${state === 'rejected' ? '거절' : ''}`;
   return (
-    <span className={`px-[10px] py-[6px] text-[12px] md:text-[14px] md:font-bold ${badgeStyle}`}>{badgeText}</span>
+    <span className={`px-[10px] py-[6px] rounded-[20px] text-[12px] md:text-[14px] md:font-bold ${badgeStyle}`}>
+      {badgeText}
+    </span>
   );
 }

--- a/components/tableStateBadge/applyTableStateBadge.tsx
+++ b/components/tableStateBadge/applyTableStateBadge.tsx
@@ -1,0 +1,11 @@
+interface ApplyTableStateBadgeProps {
+  state: 'pending' | 'accepted ' | 'rejected';
+}
+
+export default function ApplyTableStateBadge({ state }: ApplyTableStateBadgeProps) {
+  const badgeStyle = `${state === 'accepted ' ? 'bg-blue-10 text-blue-20' : ''}${state === 'pending' ? 'bg-green-10 text-green-20' : ''}${state === 'rejected' ? 'bg-red-200 text-red-500' : ''}`;
+  const badgeText = `${state === 'accepted ' ? '승인 완료' : ''}${state === 'pending' ? '대기중' : ''}${state === 'rejected' ? '거절' : ''}`;
+  return (
+    <span className={`px-[10px] py-[6px] text-[12px] md:text-[14px] md:font-bold ${badgeStyle}`}>{badgeText}</span>
+  );
+}

--- a/components/tableStateBadge/pendingBtn.tsx
+++ b/components/tableStateBadge/pendingBtn.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+export default function PendingBtn() {
+  const btnStyle =
+    'px-[12px] py-[8px] text-[12px] border md:text-[14px] md:px-[20px] md:py-[10px] rounded-[6px] md:font-bold';
+  // TODO: 거절, 승인 이벤트 달아주기
+  const handleAcceptedBtnEvent = () => {
+    console.log(1);
+  };
+  const handleRejectedBtnEvent = () => {
+    console.log(2);
+  };
+  return (
+    <div className="flex gap-3">
+      <button type="button" className={`${btnStyle} border-red-500 text-red-500`} onClick={handleAcceptedBtnEvent}>
+        거절하기
+      </button>
+      <button type="button" className={`${btnStyle} border-blue-20 text-blue-20`} onClick={handleRejectedBtnEvent}>
+        승인하기
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 테이블의 상태 뱃지를 컴포넌트로 분리하였습니다.
- [x] 테이블의 타입에 뱃지를 적용하는 로직을 구현하였습니다.
- [x] 이제 테이블의 상태 열이 고정되게 됩니다. 
- [x] pending 상태 일때 신청자 내역 테이블에서는 거절하기 승인하기 버튼이, 신청 내역 테이블일 경우 대기중 뱃지가 나오게 됩니다

## 🖼️ 스크린샷
테이블 타입이 applicationList : 신청자내역일 경우 생성되는 상태 뱃지
![스크린샷 2024-04-23 155744](https://github.com/5-PS/The-Julge/assets/143431179/6778f5a2-5001-4522-a883-4c77de5b857f)
테이블 타입이 applyList : 신청 내역일 경우 생성되는 상태 뱃지
![스크린샷 2024-04-23 160038](https://github.com/5-PS/The-Julge/assets/143431179/d4b51852-0281-410c-b775-3d9566b1c2df)
