### PR TITLE
feature: 로그인 시 직전 페이지로 이동 기능 추가

### DIFF
--- a/app/(auth)/signin/_components/signinForm.tsx
+++ b/app/(auth)/signin/_components/signinForm.tsx
@@ -10,6 +10,10 @@ import Input from '@/components/input/input';
 import ROUTE_PATHS from '@/constants/route';
 import { postSignIn } from '@/services/api';
 
+interface SignInFormProps {
+  referer: string | null;
+}
+
 interface FieldValues {
   email: string;
   password: string;
@@ -44,7 +48,7 @@ const FORM_FIELDS = [
   },
 ];
 
-export default function SignInForm() {
+export default function SignInForm({ referer }: SignInFormProps) {
   const router = useRouter();
 
   const {
@@ -61,7 +65,8 @@ export default function SignInForm() {
 
       document.cookie = `accessToken=${token}; Path=/; Max-Age=86400; Secure; SameSite=Strict`;
 
-      router.push(ROUTE_PATHS.HOME);
+      if (!referer) router.push(ROUTE_PATHS.HOME);
+      else router.push(referer);
     } catch (error) {
       if (error instanceof AxiosError) {
         const errorMessage = error.response?.status === 404 ? error.response.data.message : '로그인에 실패했습니다.';

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers';
 import Link from 'next/link';
 
 import ROUTE_PATHS from '@/constants/route';
@@ -5,9 +6,12 @@ import ROUTE_PATHS from '@/constants/route';
 import SigninForm from './_components/signinForm';
 
 export default function Signin() {
+  const headersList = headers();
+  const referer = headersList.get('referer');
+
   return (
     <div className="flex flex-col items-center">
-      <SigninForm />
+      <SigninForm referer={referer} />
       <p className="mt-5 text-black">
         회원이 아니신가요?{' '}
         <span className="text-[#5534DA] underline">


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 로그인 시 직전 페이지로 이동하는 기능을 추가하였습니다.

## 📝 참고 사항

- 직전 페이지가 존재하지 않을 경우, 메인 페이지로 이동합니다.

## 🖼️ 스크린샷

![ezgif com-video-to-gif-converter](https://github.com/5-PS/The-Julge/assets/79499733/0c2ee816-b775-4a88-b5ef-6665caff159c)

## 🚨 관련 이슈

- 회원가입 페이지에서 로그인 페이지로 이동 후, 로그인 하면, 회원가입 페이지가 아닌 이전 페이지로 잘 이동하는데, 왜 되는건지 모르겠습니다...
- The Julge 사이트가 아닌 외부 사이트에서, The Julge 로그인 페이지로 바로 이동 후, 로그인 하면, 외부 사이트가 아닌 저희 메인 페이지로 잘 이동하는데, 이것 또한 왜 되는건지 알 수 없습니다...
