### PR TITLE
feature: middleware 및 유저 데이터를 받기 위한 custom hook 추가

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -15,7 +15,7 @@ export default function AuthLayout({
     <div className="flex flex-col items-center justify-center min-h-screen py-12">
       <header className="mb-10">
         <Link href={ROUTE_PATHS.HOME}>
-          <Image src={logo} alt="The Julge logo" width={248} height={45} />
+          <Image src={logo} alt="The Julge logo" width={248} height={45} priority />
         </Link>
       </header>
       <main>{children}</main>

--- a/constants/route.ts
+++ b/constants/route.ts
@@ -2,7 +2,9 @@ const ROUTE_PATHS = {
   HOME: '/',
   SIGN_IN: '/signin',
   SIGN_UP: '/signup',
+  STORE: '/my-store',
   STORE_EDIT: '/my-store/edit',
+  PROFILE: '/my-profile',
 } as const;
 
 export default ROUTE_PATHS;

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { getUserProfile } from '@/services/api';
-import decodeJWT from '@/utils/decodeJWT';
+import { decodeJWT } from '@/utils/decodeJWT';
 
 const useUser = () => {
   const [user, setUser] = useState('');

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+import { getUserProfile } from '@/services/api';
+import decodeJWT from '@/utils/decodeJWT';
+
+const useUser = () => {
+  const [user, setUser] = useState('');
+
+  const token = document.cookie;
+  const tokenValue = token.split('=')[1];
+
+  const decodedPayload = decodeJWT(tokenValue);
+
+  const getUser = async () => {
+    const { item } = await getUserProfile(decodedPayload.userId);
+    setUser(item);
+  };
+
+  useEffect(() => {
+    getUser();
+  }, []);
+
+  return user;
+};
+
+export default useUser;

--- a/libs/axios.ts
+++ b/libs/axios.ts
@@ -2,14 +2,12 @@ import axios from 'axios';
 
 import getCookie from '@/utils/getCookie';
 
-const apiClient = axios.create({
+export const apiClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_API_URL,
   headers: {
     'Content-Type': 'application/json',
   },
 });
-
-export default apiClient;
 
 export const postRequest = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_API_URL,

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+import ROUTE_PATHS from './constants/route';
+
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('accessToken');
+
+  if (!token) {
+    return NextResponse.redirect(new URL(ROUTE_PATHS.SIGN_IN, request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/my-store/:path*', '/my-profile/:path*'],
+};

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
 
-import apiClient, { postRequest } from '@/libs/axios';
+import { apiClient, postRequest } from '@/libs/axios';
 import {
   PostSignInBody,
   PostSignupBody,
@@ -55,6 +55,11 @@ export const getNotices = async ({ offset, limit, address, startsAtGte, hourlyPa
 
 export const getPersonalNotices = async () => {
   const { data } = await apiClient.get('/notices');
+  return data;
+};
+
+export const getUserProfile = async (userId: string) => {
+  const { data } = await apiClient.get(`/users/${userId}`);
   return data;
 };
 

--- a/utils/decodeJWT.ts
+++ b/utils/decodeJWT.ts
@@ -1,0 +1,33 @@
+const decodeJWT = (token: string) => {
+  const base64UrlToBase64 = (input: string) => {
+    const replaced = input.replace(/-/g, '+').replace(/_/g, '/');
+
+    switch (replaced.length % 4) {
+      case 0:
+        break;
+      case 2:
+        return `${replaced}==`;
+      case 3:
+        return `${replaced}=`;
+      default:
+        throw new Error('유효하지 않은 토큰입니다.');
+    }
+
+    return replaced;
+  };
+
+  const decodeBase64 = (base64: string) => Buffer.from(base64, 'base64').toString('utf8');
+
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('유효하지 않은 토큰 구조입니다.');
+  }
+
+  const payload = parts[1];
+
+  const decodedPayload = decodeBase64(base64UrlToBase64(payload));
+
+  return JSON.parse(decodedPayload);
+};
+
+export default decodeJWT;


### PR DESCRIPTION
## 🚀 작업 내용

- [x] middelware를 추가하였습니다. 비로그인 상태로 `/my-store` 또는 `/my-profile` 경로에 접근 시, 로그인 페이지로 이동합니다.
- [x] 유저 데이터를 받아오기 위한 custom hook을 추가하였습니다.

## 📝 참고 사항

- `useUser` custom hook은 **client component** 내에서 다음과 같이 사용해주시면 됩니다.

  ```tsx
  const { address } = useUser();
  ```

- `useUser`로 받아오는 데이터의 형태는 다음과 같습니다.

  ![image](https://github.com/5-PS/The-Julge/assets/79499733/9639d955-1010-4f79-9024-37713284a091)

- `useUser`를 통해 얻을 수 있는 데이터는 다음과 같습니다.

  ```json
  {
    "id": "string",
    "email": "string",
    "type": "employer | employee",
    "name": "string", // optional
    "phone": "string", // optional
    "address": "string", // optional
    "bio": "string", // optional
    "shop": {
      "item": {
        "id": "string",
        "name": "string",
        "category": "string",
        "address1": "string",
        "address2": "string",
        "description": "string",
        "imageUrl": "string",
        "originalHourlyPay": "number"
      }
    } // 또는 null
  }
  ```


## ✅ 이후 계획

- 사장님 계정으로 로그인 시, `/my-profile`에 접근하지 못하는 기능을 추가할 예정입니다. (반대 경우도 마찬가지)