### PR TITLE
chore: eslint 설정 일부 비활성화

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,11 @@
   },
   "plugins": ["prettier", "import"],
   "rules": {
+    "no-alert": "off",
+    "no-console": "off",
+    "no-restricted-globals": "off",
+    "no-nested-ternary": "off",
+    "import/no-cycle": "import/no-cycle",
     "react/react-in-jsx-scope": "off",
     "react/button-has-type": "off",
     "react/jsx-props-no-spreading": "off",


### PR DESCRIPTION
## 🚀 작업 내용

- [x] 현재 경고가 뜨는 ESLint 설정들을 비활성화 시켰습니다.

## 🖼️ 스크린샷

![image](https://github.com/5-PS/The-Julge/assets/79499733/cba6f276-af27-4d8b-81bd-490a89e4acd9)

## ✅ 이후 계획

- 기능 구현 후 리팩토링 기간에 린트 설정 다시 활성화 시킬 예정입니다.